### PR TITLE
Added docs of the socket.io messages (asyncapi spec)

### DIFF
--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -3,9 +3,12 @@
 asyncapi: 3.0.0
 
 info:
-  title: Lyric Display App Socket.IO API
-  version: 5.9.5 # keep it sync with the app version
-  description: API documentation for the Lyric Display App's Socket.IO real-time communication.
+  title: LyricDisplay App Socket.IO API
+  version: 5.10.4 
+  description: |
+    Real-time control surface for LyricDisplay over Socket.IO. All connections must provide
+    a JWT in the Socket.IO auth payload (`auth.token`), minted via `/api/auth/token`.
+    Event permissions are enforced server-side per token scopes. Querystring tokens are rejected.
 
 servers:
   realtime:
@@ -20,6 +23,8 @@ channels:
       # Client -> Server (receive)
       clientConnect:
         $ref: '#/components/messages/clientConnect'
+      splitNormalGroup:
+        $ref: '#/components/messages/splitNormalGroup'
       requestCurrentState:
         $ref: '#/components/messages/requestCurrentState'
       requestSetlist:
@@ -44,6 +49,8 @@ channels:
         $ref: '#/components/messages/lyricsLoad'
       lyricsTimestampsUpdate:
         $ref: '#/components/messages/lyricsTimestampsUpdate'
+      lyricsSectionsUpdate:
+        $ref: '#/components/messages/lyricsSectionsUpdate'
       styleUpdate:
         $ref: '#/components/messages/styleUpdate'
       stageTimerUpdate:
@@ -72,6 +79,8 @@ channels:
         $ref: '#/components/messages/authError'
       currentState:
         $ref: '#/components/messages/currentState'
+      lyricsSectionsUpdate:
+        $ref: '#/components/messages/lyricsSectionsUpdate'
       permissionError:
         $ref: '#/components/messages/permissionError'
       setlistUpdate:
@@ -100,6 +109,10 @@ channels:
         $ref: '#/components/messages/serverLyricsTimestampsUpdate'
       serverStyleUpdate:
         $ref: '#/components/messages/serverStyleUpdate'
+      lyricsSplitSuccess:
+        $ref: '#/components/messages/lyricsSplitSuccess'
+      lyricsSplitError:
+        $ref: '#/components/messages/lyricsSplitError'
       serverStageTimerUpdate:
         $ref: '#/components/messages/serverStageTimerUpdate'
       serverStageMessagesUpdate:
@@ -135,6 +148,7 @@ operations:
     messages:
       - $ref: '#/channels/socketChannel/messages/clientConnect'
       - $ref: '#/channels/socketChannel/messages/requestCurrentState'
+      - $ref: '#/channels/socketChannel/messages/splitNormalGroup'
       - $ref: '#/channels/socketChannel/messages/requestSetlist'
       - $ref: '#/channels/socketChannel/messages/setlistAdd'
       - $ref: '#/channels/socketChannel/messages/setlistRemove'
@@ -146,6 +160,7 @@ operations:
       - $ref: '#/channels/socketChannel/messages/individualOutputToggle'
       - $ref: '#/channels/socketChannel/messages/lyricsLoad'
       - $ref: '#/channels/socketChannel/messages/lyricsTimestampsUpdate'
+      - $ref: '#/channels/socketChannel/messages/lyricsSectionsUpdate'
       - $ref: '#/channels/socketChannel/messages/styleUpdate'
       - $ref: '#/channels/socketChannel/messages/stageTimerUpdate'
       - $ref: '#/channels/socketChannel/messages/stageMessagesUpdate'
@@ -165,6 +180,7 @@ operations:
     messages:
       - $ref: '#/channels/socketChannel/messages/authError'
       - $ref: '#/channels/socketChannel/messages/currentState'
+      - $ref: '#/channels/socketChannel/messages/lyricsSectionsUpdate'
       - $ref: '#/channels/socketChannel/messages/permissionError'
       - $ref: '#/channels/socketChannel/messages/setlistUpdate'
       - $ref: '#/channels/socketChannel/messages/setlistError'
@@ -179,6 +195,8 @@ operations:
       - $ref: '#/channels/socketChannel/messages/serverLyricsLoad'
       - $ref: '#/channels/socketChannel/messages/serverLyricsTimestampsUpdate'
       - $ref: '#/channels/socketChannel/messages/serverStyleUpdate'
+      - $ref: '#/channels/socketChannel/messages/lyricsSplitSuccess'
+      - $ref: '#/channels/socketChannel/messages/lyricsSplitError'
       - $ref: '#/channels/socketChannel/messages/serverStageTimerUpdate'
       - $ref: '#/channels/socketChannel/messages/serverStageMessagesUpdate'
       - $ref: '#/channels/socketChannel/messages/serverOutputMetrics'
@@ -227,6 +245,14 @@ components:
               description: Combined text for search
             originalIndex:
               type: integer
+            sections:
+              type: array
+              description: Optional derived sections for LRC or TXT parsing
+              items:
+                type: object
+            lineToSection:
+              type: object
+              description: Mapping of line index to section index
     
     SetlistItemInput:
       type: object
@@ -265,6 +291,14 @@ components:
         metadata:
           type: object
           nullable: true
+        sections:
+          type: array
+          nullable: true
+          items:
+            type: object
+        lineToSection:
+          type: object
+          nullable: true
         addedBy:
           type: object
           properties:
@@ -285,34 +319,55 @@ components:
           type:
             type: string
             enum: ['desktop', 'web', 'output1', 'output2', 'stage', 'mobile']
+      description: Must be sent after successful authenticated connection.
+      x-permissions: ['lyrics:read']
+    splitNormalGroup:
+      name: splitNormalGroup
+      payload:
+        oneOf:
+          - type: integer
+          - type: object
+            properties:
+              index:
+                type: integer
+      description: Split a 'normal-group' line into two separate lines.
+      x-permissions: ['output:control']
     requestCurrentState:
       name: requestCurrentState
       payload:
         type: 'null'
+      x-permissions: ['lyrics:read']
     requestSetlist:
       name: requestSetlist
       payload:
         type: 'null'
+      x-permissions: ['setlist:read']
     setlistAdd:
       name: setlistAdd
       payload:
         type: array
         items:
           $ref: '#/components/schemas/SetlistItemInput'
+      description: Adds up to 50 items total; rejects duplicates by normalized name.
+      x-permissions: ['setlist:write']
     setlistRemove:
       name: setlistRemove
       payload:
         type: string
         description: File ID to remove
+      description: Non-admin clients may only remove items they added.
+      x-permissions: ['setlist:write']
     setlistLoad:
       name: setlistLoad
       payload:
         type: string
         description: File ID to load
+      x-permissions: ['setlist:read']
     setlistClear:
       name: setlistClear
       payload:
         type: 'null'
+      x-permissions: ['setlist:delete']
     setlistReorder:
       name: setlistReorder
       payload:
@@ -326,6 +381,7 @@ components:
                 type: array
                 items:
                   type: string
+      x-permissions: ['setlist:write']
     lineUpdate:
       name: lineUpdate
       payload:
@@ -334,10 +390,12 @@ components:
           index:
             type: integer
             description: Index of the selected line
+      x-permissions: ['output:control']
     outputToggle:
       name: outputToggle
       payload:
         type: boolean
+      x-permissions: ['output:control']
     individualOutputToggle:
       name: individualOutputToggle
       payload:
@@ -348,12 +406,14 @@ components:
             enum: ['output1', 'output2', 'stage']
           enabled:
             type: boolean
+      x-permissions: ['output:control']
     lyricsLoad:
       name: lyricsLoad
       payload:
         type: array
         items:
           $ref: '#/components/schemas/LyricLine'
+      x-permissions: ['lyrics:write']
     lyricsTimestampsUpdate:
       name: lyricsTimestampsUpdate
       payload:
@@ -365,6 +425,18 @@ components:
               type: number
             lineIndex:
               type: integer
+      x-permissions: ['lyrics:write']
+    lyricsSectionsUpdate:
+      name: lyricsSectionsUpdate
+      payload:
+        type: object
+        properties:
+          sections:
+            type: array
+          lineToSection:
+            type: object
+      description: Sends derived sections and mapping for loaded lyrics.
+      x-permissions: ['lyrics:write']
     styleUpdate:
       name: styleUpdate
       payload:
@@ -375,6 +447,8 @@ components:
             enum: ['output1', 'output2', 'stage']
           settings:
             type: object
+      description: Update styling for a specific output. Mirrors to all clients.
+      x-permissions: ['settings:write']
     stageTimerUpdate:
       name: stageTimerUpdate
       payload:
@@ -390,12 +464,14 @@ components:
           remaining:
             type: integer
             nullable: true
+      x-permissions: ['output:control']
     stageMessagesUpdate:
       name: stageMessagesUpdate
       payload:
         type: array
         items:
           type: object
+      x-permissions: ['output:control']
     outputMetrics:
       name: outputMetrics
       payload:
@@ -417,10 +493,13 @@ components:
                 type: number
               timestamp:
                 type: integer
+      description: Output instances publish autosizer and viewport metrics.
+      x-permissions: ['lyrics:read']
     fileNameUpdate:
       name: fileNameUpdate
       payload:
         type: string
+      x-permissions: ['lyrics:write']
     lyricsDraftSubmit:
       name: lyricsDraftSubmit
       payload:
@@ -434,6 +513,8 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/LyricLine'
+      description: Controllers submit drafts; desktop must approve.
+      x-permissions: ['lyrics:draft']
     lyricsDraftApprove:
       name: lyricsDraftApprove
       payload:
@@ -449,6 +530,7 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/LyricLine'
+      x-permissions: ['lyrics:write']
     lyricsDraftReject:
       name: lyricsDraftReject
       payload:
@@ -460,6 +542,7 @@ components:
             type: string
           reason:
             type: string
+      x-permissions: ['lyrics:write']
     autoplayStateUpdate:
       name: autoplayStateUpdate
       payload:
@@ -469,6 +552,7 @@ components:
             type: boolean
           clientType:
             type: string
+      x-permissions: ['output:control']
     heartbeat:
       name: heartbeat
       payload:
@@ -493,10 +577,44 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/LyricLine'
+          lyricsTimestamps:
+            type: array
+            items:
+              type: object
+          lyricsSections:
+            type: array
+          lineToSection:
+            type: object
           setlistFiles:
             type: array
             items:
               $ref: '#/components/schemas/SetlistItem'
+          output1Settings:
+            type: object
+          output2Settings:
+            type: object
+          stageSettings:
+            type: object
+          isOutputOn:
+            type: boolean
+          output1Enabled:
+            type: boolean
+          output2Enabled:
+            type: boolean
+          stageEnabled:
+            type: boolean
+          lyricsFileName:
+            type: string
+          isDesktopClient:
+            type: boolean
+          clientPermissions:
+            type: array
+            items:
+              type: string
+          timestamp:
+            type: integer
+          syncTimestamp:
+            type: integer
           # ... Add other state properties as required
     permissionError:
       name: permissionError
@@ -599,6 +717,15 @@ components:
         type: array
         items:
           type: object
+    lyricsSectionsUpdate:
+      name: lyricsSectionsUpdate
+      payload:
+        type: object
+        properties:
+          sections:
+            type: array
+          lineToSection:
+            type: object
     serverStyleUpdate:
       name: styleUpdate
       payload:
@@ -608,6 +735,17 @@ components:
             type: string
           settings:
             type: object
+    lyricsSplitSuccess:
+      name: lyricsSplitSuccess
+      payload:
+        type: object
+        properties:
+          index:
+            type: integer
+    lyricsSplitError:
+      name: lyricsSplitError
+      payload:
+        type: string
     serverStageTimerUpdate:
       name: stageTimerUpdate
       payload:


### PR DESCRIPTION
Added an `asyncapi.yml` to document the messages of the socket.io stream.

This help in integration with external controllers like bitfocus companion and other custom integrations in complex workflows.

Keep this in sync when any of the socket related stuff changes.

Please go through it once. If everything is alright.