### PR TITLE
harden: sanitize child_process call in lyricVideoExport.js...

### DIFF
--- a/main/ipc/ffmpegProbe.js
+++ b/main/ipc/ffmpegProbe.js
@@ -5,9 +5,9 @@ import { spawn } from 'node:child_process';
 // It is never supplied by the lyric-video export IPC request, so no path.resolve/sanitization
 // is applied here — doing so (e.g. path.resolve('ffmpeg') -> <cwd>/ffmpeg) would break PATH
 // discovery. shell:false is set explicitly and args are passed as a separate array.
-// nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
 export const runProbeProcess = async (executablePath, args, timeoutMs, label) => new Promise((resolve) => {
   const startedAt = Date.now();
+  // nosemgrep: javascript.lang.security.detect-child-process.detect-child-process -- executable resolved at the resolveFfmpegPath() trust boundary, not from IPC input; shell:false with array args
   const child = spawn(executablePath, args, { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'], shell: false });
   let stderr = '';
   let settled = false;

--- a/main/ipc/ffmpegProbe.js
+++ b/main/ipc/ffmpegProbe.js
@@ -1,0 +1,44 @@
+import { spawn } from 'node:child_process';
+
+// The executable path is resolved internally by resolveFfmpegPath() (the trust boundary):
+// a validated configured/bundled path, or the intentional bare `ffmpeg` for OS PATH lookup.
+// It is never supplied by the lyric-video export IPC request, so no path.resolve/sanitization
+// is applied here — doing so (e.g. path.resolve('ffmpeg') -> <cwd>/ffmpeg) would break PATH
+// discovery. shell:false is set explicitly and args are passed as a separate array.
+// nosemgrep: javascript.lang.security.detect-child-process.detect-child-process
+export const runProbeProcess = async (executablePath, args, timeoutMs, label) => new Promise((resolve) => {
+  const startedAt = Date.now();
+  const child = spawn(executablePath, args, { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'], shell: false });
+  let stderr = '';
+  let settled = false;
+  const finish = (result) => {
+    if (settled) return;
+    settled = true;
+    clearTimeout(timeout);
+    resolve({
+      ...result,
+      durationMs: Date.now() - startedAt,
+      stderr: stderr.trim().slice(-1200),
+    });
+  };
+  const timeout = setTimeout(() => {
+    try {
+      child.kill('SIGTERM');
+    } catch { }
+    finish({ ok: false, reason: `${label} timed out` });
+  }, timeoutMs);
+
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+    if (stderr.length > 3000) stderr = stderr.slice(-3000);
+  });
+  child.once('error', (error) => {
+    finish({ ok: false, reason: error?.message || `${label} failed to start` });
+  });
+  child.once('exit', (code) => {
+    finish({
+      ok: code === 0,
+      reason: code === 0 ? 'ok' : `${label} exited with code ${code}`,
+    });
+  });
+});

--- a/main/ipc/lyricVideoExport.js
+++ b/main/ipc/lyricVideoExport.js
@@ -15,6 +15,7 @@ import {
   normalizeLyricVideoVisualizer,
 } from '../../shared/lyricVideoVisualizer.js';
 import { extractZipArchive } from '../archiveExtraction.js';
+import { runProbeProcess } from './ffmpegProbe.js';
 
 let activeExport = null;
 let captureRawFormatCache = null;
@@ -102,44 +103,6 @@ const writeToStream = async (stream, chunk) => {
   });
 };
 
-const runProbeProcess = async (executablePath, args, timeoutMs, label) => new Promise((resolve) => {
-  const startedAt = Date.now();
-  const safePath = path.resolve(executablePath);
-  const child = spawn(safePath, args, { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'], shell: false });
-  let stderr = '';
-  let settled = false;
-  const finish = (result) => {
-    if (settled) return;
-    settled = true;
-    clearTimeout(timeout);
-    resolve({
-      ...result,
-      durationMs: Date.now() - startedAt,
-      stderr: stderr.trim().slice(-1200),
-    });
-  };
-  const timeout = setTimeout(() => {
-    try {
-      child.kill('SIGTERM');
-    } catch { }
-    finish({ ok: false, reason: `${label} timed out` });
-  }, timeoutMs);
-
-  child.stderr.on('data', (chunk) => {
-    stderr += chunk.toString();
-    if (stderr.length > 3000) stderr = stderr.slice(-3000);
-  });
-  child.once('error', (error) => {
-    finish({ ok: false, reason: error?.message || `${label} failed to start` });
-  });
-  child.once('exit', (code) => {
-    finish({
-      ok: code === 0,
-      reason: code === 0 ? 'ok' : `${label} exited with code ${code}`,
-    });
-  });
-});
-
 const getFfmpegExecutableNames = () => (
   process.platform === 'win32' ? ['ffmpeg.exe', 'ffmpeg'] : ['ffmpeg']
 );
@@ -183,6 +146,12 @@ const getBundledFfmpegCandidates = () => {
   return roots.flatMap((root) => names.map((name) => path.join(root, name)));
 };
 
+// Single trust boundary for choosing the FFmpeg executable. Configured paths
+// (advanced.ffmpegPath) are validated by name (isFfmpegExecutableName) and existence before
+// use; FFMPEG_PATH is an operator-supplied escape hatch; bundled candidates are validated by
+// construction. The final `return 'ffmpeg'` is the intentional bare-command fallback that must
+// stay unmodified so FFmpeg is discovered via the OS PATH — never wrap it in path.resolve() at
+// a spawn site, which would turn it into <cwd>/ffmpeg and defeat PATH lookup.
 const resolveFfmpegPath = async () => {
   const savedPath = userPreferences.getPreference('advanced.ffmpegPath');
   if (typeof savedPath === 'string' && savedPath.trim()) {

--- a/main/ipc/lyricVideoExport.js
+++ b/main/ipc/lyricVideoExport.js
@@ -102,9 +102,10 @@ const writeToStream = async (stream, chunk) => {
   });
 };
 
-const runProbeProcess = async (command, args, timeoutMs, label) => new Promise((resolve) => {
+const runProbeProcess = async (executablePath, args, timeoutMs, label) => new Promise((resolve) => {
   const startedAt = Date.now();
-  const child = spawn(command, args, { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'] });
+  const safePath = path.resolve(executablePath);
+  const child = spawn(safePath, args, { windowsHide: true, stdio: ['ignore', 'ignore', 'pipe'], shell: false });
   let stderr = '';
   let settled = false;
   const finish = (result) => {

--- a/tests/ffmpeg-probe-path.test.js
+++ b/tests/ffmpeg-probe-path.test.js
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { runProbeProcess } from '../main/ipc/ffmpegProbe.js';
+
+// These tests exercise the hardware-encoder probe helper against a fake `ffmpeg` binary placed
+// on PATH. They guard the regression from commit 27a5bc3, where path.resolve('ffmpeg') turned
+// the intentional bare PATH fallback into <cwd>/ffmpeg and broke hardware-encoder detection.
+//
+// The fake binary is a POSIX shell script, so the test is skipped on Windows (PATH/PATHEXT
+// resolution for real executables is covered by the platform-build workflow instead).
+const skip = process.platform === 'win32' ? 'POSIX fake executable is not runnable on Windows' : false;
+
+async function withFakeFfmpegOnPath(run) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'lyricdisplay-ffmpeg-probe-'));
+  const fakeFfmpeg = path.join(dir, 'ffmpeg');
+  await writeFile(fakeFfmpeg, '#!/bin/sh\nexit 0\n', 'utf8');
+  await chmod(fakeFfmpeg, 0o755);
+
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${dir}${path.delimiter}${originalPath || ''}`;
+  try {
+    return await run({ dir });
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('runProbeProcess resolves a bare ffmpeg command through PATH', { skip }, async () => {
+  await withFakeFfmpegOnPath(async () => {
+    const result = await runProbeProcess('ffmpeg', ['-version'], 5000, 'ffmpeg probe');
+    assert.equal(result.ok, true, `bare "ffmpeg" should be found via PATH, got: ${result.reason}`);
+  });
+});
+
+test('runProbeProcess with a path.resolve()d bare command fails (documents the fixed regression)', { skip }, async () => {
+  await withFakeFfmpegOnPath(async () => {
+    // path.resolve('ffmpeg') yields <cwd>/ffmpeg, which does not exist — this is exactly the
+    // behavior the reverted hardening introduced, breaking PATH-based hardware detection.
+    const resolved = path.resolve('ffmpeg');
+    const result = await runProbeProcess(resolved, ['-version'], 5000, 'ffmpeg probe');
+    assert.equal(result.ok, false, 'resolving the bare command to <cwd>/ffmpeg should fail to spawn');
+  });
+});

--- a/tests/ffmpeg-probe-path.test.js
+++ b/tests/ffmpeg-probe-path.test.js
@@ -1,47 +1,57 @@
 import assert from 'node:assert/strict';
-import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, copyFile, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import test from 'node:test';
+import test, { after, before } from 'node:test';
 import { runProbeProcess } from '../main/ipc/ffmpegProbe.js';
 
 // These tests exercise the hardware-encoder probe helper against a fake `ffmpeg` binary placed
 // on PATH. They guard the regression from commit 27a5bc3, where path.resolve('ffmpeg') turned
 // the intentional bare PATH fallback into <cwd>/ffmpeg and broke hardware-encoder detection.
 //
-// The fake binary is a POSIX shell script, so the test is skipped on Windows (PATH/PATHEXT
-// resolution for real executables is covered by the platform-build workflow instead).
-const skip = process.platform === 'win32' ? 'POSIX fake executable is not runnable on Windows' : false;
+// The fixture is a real, self-contained executable that exits 0 regardless of args, so the
+// test verifies PATH resolution on every platform (no skips):
+//   * Windows: a copy of the Node binary named ffmpeg.exe (the Windows node.exe is
+//     self-contained), driven with `-e process.exit(0)`. The bare `ffmpeg` lookup then
+//     resolves via PATH + PATHEXT, mirroring resolveFfmpegPath()'s bare fallback.
+//   * POSIX: a tiny `#!/bin/sh` stub named ffmpeg that exits 0, avoiding any dependency on the
+//     Node runtime's (possibly shared-library) install layout.
+const IS_WINDOWS = process.platform === 'win32';
+const EXE_NAME = IS_WINDOWS ? 'ffmpeg.exe' : 'ffmpeg';
+const PROBE_ARGS = IS_WINDOWS ? ['-e', 'process.exit(0)'] : ['-version'];
+const PROBE_TIMEOUT_MS = 10_000;
 
-async function withFakeFfmpegOnPath(run) {
-  const dir = await mkdtemp(path.join(os.tmpdir(), 'lyricdisplay-ffmpeg-probe-'));
-  const fakeFfmpeg = path.join(dir, 'ffmpeg');
-  await writeFile(fakeFfmpeg, '#!/bin/sh\nexit 0\n', 'utf8');
-  await chmod(fakeFfmpeg, 0o755);
+let fixtureDir = null;
+let originalPath = null;
 
-  const originalPath = process.env.PATH;
-  process.env.PATH = `${dir}${path.delimiter}${originalPath || ''}`;
-  try {
-    return await run({ dir });
-  } finally {
-    process.env.PATH = originalPath;
-    await rm(dir, { recursive: true, force: true });
+before(async () => {
+  fixtureDir = await mkdtemp(path.join(os.tmpdir(), 'lyricdisplay-ffmpeg-probe-'));
+  const fakeFfmpeg = path.join(fixtureDir, EXE_NAME);
+  if (IS_WINDOWS) {
+    await copyFile(process.execPath, fakeFfmpeg);
+  } else {
+    await writeFile(fakeFfmpeg, '#!/bin/sh\nexit 0\n', 'utf8');
   }
-}
-
-test('runProbeProcess resolves a bare ffmpeg command through PATH', { skip }, async () => {
-  await withFakeFfmpegOnPath(async () => {
-    const result = await runProbeProcess('ffmpeg', ['-version'], 5000, 'ffmpeg probe');
-    assert.equal(result.ok, true, `bare "ffmpeg" should be found via PATH, got: ${result.reason}`);
-  });
+  await chmod(fakeFfmpeg, 0o755);
+  originalPath = process.env.PATH;
+  process.env.PATH = `${fixtureDir}${path.delimiter}${originalPath || ''}`;
 });
 
-test('runProbeProcess with a path.resolve()d bare command fails (documents the fixed regression)', { skip }, async () => {
-  await withFakeFfmpegOnPath(async () => {
-    // path.resolve('ffmpeg') yields <cwd>/ffmpeg, which does not exist — this is exactly the
-    // behavior the reverted hardening introduced, breaking PATH-based hardware detection.
-    const resolved = path.resolve('ffmpeg');
-    const result = await runProbeProcess(resolved, ['-version'], 5000, 'ffmpeg probe');
-    assert.equal(result.ok, false, 'resolving the bare command to <cwd>/ffmpeg should fail to spawn');
-  });
+after(async () => {
+  process.env.PATH = originalPath;
+  if (fixtureDir) await rm(fixtureDir, { recursive: true, force: true });
+});
+
+test('runProbeProcess resolves a bare ffmpeg command through PATH', async () => {
+  const result = await runProbeProcess('ffmpeg', PROBE_ARGS, PROBE_TIMEOUT_MS, 'ffmpeg probe');
+  assert.equal(result.ok, true, `bare "ffmpeg" should resolve via PATH, got: ${result.reason}`);
+});
+
+test('runProbeProcess with a path.resolve()d bare command bypasses PATH and fails', async () => {
+  // path.resolve('ffmpeg') yields <cwd>/ffmpeg (the repo root, which has no ffmpeg binary), so
+  // it can never reach the fixture on PATH — exactly the behavior the reverted hardening
+  // introduced, breaking PATH-based hardware detection.
+  const resolved = path.resolve('ffmpeg');
+  const result = await runProbeProcess(resolved, PROBE_ARGS, PROBE_TIMEOUT_MS, 'ffmpeg probe');
+  assert.equal(result.ok, false, 'resolving the bare command to <cwd>/ffmpeg should bypass PATH and fail');
 });


### PR DESCRIPTION
## Summary
Address a Semgrep `detect-child-process` finding in `main/ipc/lyricVideoExport.js` while preserving FFmpeg discovery behavior.

This code path is Electron main-process IPC, **not** a web service. The FFmpeg executable passed to `spawn` is resolved internally by `resolveFfmpegPath()` (configured `advanced.ffmpegPath` → `FFMPEG_PATH` → bundled binary → bare `ffmpeg` for OS PATH lookup) and is **never** derived from the `lyric-video:export-video` request payload. `spawn` runs with `shell: false` and arguments as a separate array, so there is no shell-injection surface. `resolveFfmpegPath()` is the single trust boundary and already validates configured paths by name and existence; the bare `ffmpeg` fallback is intentional so FFmpeg is found on the system PATH.

The scanner `detect-child-process` match is a false positive for this data flow. It is suppressed at the call site with a justified `nosemgrep` referencing the trust boundary.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.lang.security.detect-child-process.detect-child-process |
| **Severity** | MEDIUM |
| **Scanner** | semgrep |
| **Rule** | `javascript.lang.security.detect-child-process.detect-child-process` |
| **File** | `main/ipc/ffmpegProbe.js` (probe helper extracted from `main/ipc/lyricVideoExport.js`) |
| **Assessment** | False positive for this data flow — executable is resolved internally, not from request input |

**Description**: Semgrep flags calls to `child_process` from a function argument, which could allow command injection *if the argument were user-controllable*. Here the argument is the FFmpeg path chosen by `resolveFfmpegPath()` inside the main process; it is not attacker-controllable via IPC, and `spawn` uses `shell: false` with array args.

## Threat Model Context

Electron main-process IPC. The lyric-video export request does not supply the executable path; it is resolved internally (configured → env → bundled → system PATH). There is no remote/web-service request surface on this code path.

## Changes
- `main/ipc/ffmpegProbe.js` (new) — extracted `runProbeProcess`; spawns the resolved FFmpeg path with `shell: false` and array args; no `path.resolve` on the command; `nosemgrep` placed on the spawn line with a justification.
- `main/ipc/lyricVideoExport.js` — imports the helper; documents `resolveFfmpegPath()` as the single resolution trust boundary.
- `tests/ffmpeg-probe-path.test.js` (new) — cross-platform regression test proving a bare `ffmpeg` on PATH stays usable by the hardware-encoder probe, and that `path.resolve('ffmpeg')` bypasses PATH.

## Behaviour Preservation
No change to valid inputs. The executable is still resolved by `resolveFfmpegPath()` and the bare-`ffmpeg` PATH fallback is preserved, so hardware-encoder detection continues to work on systems relying on a PATH-installed FFmpeg. This is verified by the new `tests/ffmpeg-probe-path.test.js` regression test.
